### PR TITLE
NEXT-36 Introduce unit test for NEXT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 
+node_js:
+  - "4.1"
+
 notifications:
   webhooks:
     urls:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_script:
 
 script:
   - ./node_modules/.bin/gulp lint
+  - ./node_modules/.bin/gulp test
   - ./node_modules/.bin/gulp build
 
 after_success:

--- a/client/js/animated-value.js
+++ b/client/js/animated-value.js
@@ -7,7 +7,7 @@ class AnimatedValue {
 
   get() {
     if (this.timeout) {
-      const now = performance.now();
+      const now = Date.now();
       const end = this.frTime + this.timeout;
       if (now >= end) {
         this.timeout = 0;
@@ -29,7 +29,7 @@ class AnimatedValue {
       this.toVal = value;
       this.timeout = timeout;
       this.following = undefined;
-      this.frTime = performance.now();
+      this.frTime = Date.now();
     }
   }
 
@@ -37,14 +37,14 @@ class AnimatedValue {
     this.frVal = this.get();
     this.following = following;
     this.timeout = timeout;
-    this.frTime = performance.now();
+    this.frTime = Date.now();
   }
 
   write(value) {
     this.frVal = value;
     this.toVal = value;
     this.timeout = 0;
-    this.frTime = performance.now(); // so end == now
+    this.frTime = Date.now(); // so end == now
   }
 }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,6 +10,7 @@ var runSeq      = require('run-sequence');
 var stylish     = require('jshint-stylish');
 var jscs        = require('gulp-jscs');
 var browserSync = require('browser-sync').create();
+var mocha       = require('gulp-mocha');
 
 gulp.task('css', function () {
   gulp.src(['client/css/layout.css'])
@@ -60,18 +61,23 @@ gulp.task('dev', function () {
 });
 
 gulp.task('jshint', function () {
-  return gulp.src(['./client/js/*.js', './gulpfile.js'])
+  return gulp.src(['./client/js/*.js', './test/*.js', './gulpfile.js'])
     .pipe(jshint())
     .pipe(jshint.reporter(stylish))
     .pipe(jshint.reporter('fail'));
 });
 
 gulp.task('jscs', function () {
-  return gulp.src(['./client/js/*.js', './gulpfile.js'])
+  return gulp.src(['./client/js/*.js', './test/*.js', './gulpfile.js'])
     .pipe(jscs())
     .pipe(jscs.reporter());
 });
 
 gulp.task('lint', function () {
   runSeq('jshint', 'jscs');
+});
+
+gulp.task('test', function () {
+  return gulp.src(['./test/*.js'])
+    .pipe(mocha());
 });

--- a/package.json
+++ b/package.json
@@ -9,16 +9,19 @@
   "license": "ISC",
   "devDependencies": {
     "browser-sync": "^2.11.1",
+    "chai": "^3.5.0",
     "gulp": "^3.9.0",
     "gulp-cssnano": "^2.1.0",
     "gulp-htmlmin": "^1.3.0",
     "gulp-jscs": "^3.0.2",
     "gulp-jshint": "^2.0.0",
     "gulp-jspm": "^0.5.6",
+    "gulp-mocha": "^2.2.0",
     "gulp-rename": "^1.2.2",
     "jshint": "^2.9.1",
     "jshint-stylish": "^2.1.0",
     "jspm": "^0.16.25",
+    "mocha": "^2.4.5",
     "run-sequence": "^1.1.5"
   },
   "jspm": {

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -4,12 +4,7 @@
   "node": true,
   "expr": true,
   "esnext": true,
+  "mocha": true,
   "globals": {
-    "describe"   : false,
-    "it"         : false,
-    "before"     : false,
-    "beforeEach" : false,
-    "after"      : false,
-    "afterEach"  : false
   }
 }

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,0 +1,15 @@
+{
+  "globalstrict": true,
+  "browser": true,
+  "node": true,
+  "expr": true,
+  "esnext": true,
+  "globals": {
+    "describe"   : false,
+    "it"         : false,
+    "before"     : false,
+    "beforeEach" : false,
+    "after"      : false,
+    "afterEach"  : false
+  }
+}

--- a/test/animated-value.js
+++ b/test/animated-value.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const AnimatedValue = require('../client/js/animated-value');
+const expect = require('chai').expect;
+
+describe('AnimatedValue', function () {
+  describe('.constructor()', function () {
+    it('should set initial value', function () {
+      expect(new AnimatedValue(10).get()).to.be.equal(10);
+      expect(new AnimatedValue(20).get()).to.be.equal(20);
+    });
+  });
+
+  describe('.write()', function () {
+    it('should set value immediately', function () {
+      let v = new AnimatedValue(10);
+      v.write(20);
+      expect(v.get()).to.be.equal(20);
+    });
+  });
+
+  describe('.set()', function () {
+    it('should not set value immediately', function () {
+      let v = new AnimatedValue(10);
+      v.set(20, 50);
+      expect(v.get()).to.be.equal(10);
+    });
+    it('should set value after some time', function (done) {
+      let v = new AnimatedValue(10);
+      v.set(20, 50);
+      setTimeout(() => {
+        expect(v.get()).to.be.equal(20);
+        done();
+      }, 60);
+    });
+  });
+
+  describe('.follow()', function () {
+    // test is not implemented yet
+  });
+});

--- a/test/map-size.js
+++ b/test/map-size.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const MapSize = require('../client/js/map-size');
+const expect = require('chai').expect;
+
+describe('MapSize', function () {
+  it('should have proper centerX', function () {
+    expect(new MapSize(-10, -20, 30, 50).centerX()).to.be.equal(10);
+  });
+
+  it('should have proper centerY', function () {
+    expect(new MapSize(-10, -20, 30, 50).centerY()).to.be.equal(15);
+  });
+
+  it('should have proper width', function () {
+    expect(new MapSize(-10, -20, 30, 50).width()).to.be.equal(40);
+  });
+
+  it('should have proper height', function () {
+    expect(new MapSize(-10, -20, 30, 50).height()).to.be.equal(70);
+  });
+
+  it('should have default() constructor', function () {
+    expect(MapSize.default()).to.be.an.instanceof(MapSize);
+  });
+});

--- a/test/misc.js
+++ b/test/misc.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const Misc = require('../client/js/misc.js');
+const expect = require('chai').expect;
+
+describe('Misc', function () {
+  describe('.ensureRange()', function () {
+    it('should return left boundary if the value below left boundary', function () {
+      expect(Misc.ensureRange(-50, -20, +20)).to.be.equal(-20);
+    });
+
+    it('should return right boundary if the value above right boundary', function () {
+      expect(Misc.ensureRange(+50, -20, +20)).to.be.equal(+20);
+    });
+
+    it('should return the value if the value is within boundaries', function () {
+      expect(Misc.ensureRange(+15, -20, +20)).to.be.equal(+15);
+    });
+  });
+});


### PR DESCRIPTION
Added tests for:
* `animated-value.js`
* `map-size.js`
* `misc.js`

Tests are not added for:
* `ball-view.js` - uses pixi.
* `connector.js` - uses XMLHttpRequest. Can be mocked however.
* `constants.js` - no need to test.
* `controller.js` - uses pixi.
* `main.js` - no need to test.
* `pointer.js` - relies on `Viewer` object that passed into it; also mouse events.
* `viewer.js` - uses pixi.